### PR TITLE
Turn off SSL redirect when running locally

### DIFF
--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -28,7 +28,7 @@ DEBUG = False if os.environ.get('DEBUG', 'False') == 'False' else True
 
 ALLOWED_HOSTS = ['*']
 # enforce HTTPS/SSL
-SECURE_SSL_REDIRECT = True
+SECURE_SSL_REDIRECT = False if os.environ.get('LOCAL', '') else True
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 # Application definition

--- a/webapp_env.sh
+++ b/webapp_env.sh
@@ -22,3 +22,5 @@ export DEV_DEBUG=True
 export HTML_MINIFY=True
 
 export WORKERS=127.0.0.1:5050
+
+export LOCAL=True


### PR DESCRIPTION
This PR allows the webapp to be run without https when doing local development. It seems infeasible/in-practical to give the webapp the appearance of https access locally.