### PR TITLE
Add feature roadmap to the readme and home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,16 @@
 
 To see COMP in action, visit [compmodels.com](www.compmodels.com).
 
+Features:
 - Developers share their public models for free.
-- Developers share private models for a per-user fee.
 - Users pay for their own compute, at cost.
+
+Under development: 
+- Developers may pay for their users' compute.
+- Developers may share models privately, for a per-user fee.
+
+Planned:
+- Developers may charge a subscription for their model to support development and data. 
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -9,11 +9,15 @@ Features:
 - Users pay for their own compute, at cost.
 
 Under development: 
-- Developers may pay for their users' compute.
-- Developers may share models privately, for a per-user fee.
+- Developers choose to pay for their users' compute.
+- Developers coose to share models privately, for a fee.
+- Developers may share non-tabular output. 
 
 Planned:
-- Developers may charge a subscription for their model to support development and data. 
+- Users may use a COMP REST API to run simulations and build GUI simulation pages.  
+- Developers may charge a model subscription, for a fee.
+- Users may upload and download simulation input files from the COMP GUI. 
+
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Under development:
 - Developers may share non-tabular output. 
 
 Planned:
-- Users may use a COMP REST API to run simulations and build GUI simulation pages.  
+- Users may use a REST API to run simulations and build GUI simulation pages.  
 - Developers may charge a model subscription, for a fee.
-- Users may upload and download simulation input files from the COMP GUI. 
+- Users may upload and download simulation input files from the GUI. 
 
 
 


### PR DESCRIPTION
This may be helpful during our alpha testing stage so folks can see how the business and product are likely to evolve and give us feedback on the evolution. It will also lower the burden for us to communicate this email and other mediums. 