### PR TITLE
Fix login and list fields

### DIFF
--- a/templates/registration/signup.html
+++ b/templates/registration/signup.html
@@ -9,9 +9,11 @@
   <form method="post" id="payment-form">
     {% csrf_token %}
     {% include 'includes/prettyform.html' with form=form %}
-    <div class='stripe-input'>
-      {% include 'billing/base.html' %}
-    </div>
+    {% if use_stripe %}
+      <div class='stripe-input'>
+        {% include 'billing/base.html' %}
+      </div>
+    {% endif %}
     <button style="margin: 10px;" type="submit" class="btn btn-comp">Sign up</button>
   </form>
 {% endblock %}

--- a/webapp/apps/core/param.py
+++ b/webapp/apps/core/param.py
@@ -10,6 +10,8 @@ class SeparatedValue:
                  **field_kwargs):
         self.name = name
         self.label = label
+        if number_dims > 0:
+            default_value = ', '.join([str(v) for v in default_value])
         attrs = {
             'class': 'form-control',
             'placeholder': default_value,

--- a/webapp/apps/users/views.py
+++ b/webapp/apps/users/views.py
@@ -5,6 +5,8 @@ from django.shortcuts import render
 from django.utils.decorators import method_decorator
 from django.contrib.auth.decorators import login_required, user_passes_test
 
+from webapp.apps.billing.utils import USE_STRIPE
+
 from .forms import UserCreationForm, CancelSubscriptionForm, DeleteUserForm
 from .models import is_profile_active
 
@@ -17,6 +19,10 @@ class SignUp(generic.CreateView):
     def post(self, request, *args, **kwargs):
         return super().post(request, *args, **kwargs)
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["use_stripe"] = USE_STRIPE
+        return context
 
 class UserProfile(View):
     template_name = 'registration/profile_base.html',


### PR DESCRIPTION
Stripe requires a public key to be set in the javascript. I'm not sure how to swap out the live key for the test key since it is embedded in the javascript. For now, the CC info intake will just be removed when stripe is not being used.

It also fixes an issue where list fields were displayed like `['Freddie Freeman', 'Jose Altuve']` instead of `Freddie Freeman, Jose Altuve`.