### PR TITLE
Fix up the output buttons

### DIFF
--- a/distributed/dockerfiles/projects/Dockerfile.compbaseball_tasks
+++ b/distributed/dockerfiles/projects/Dockerfile.compbaseball_tasks
@@ -11,7 +11,7 @@ RUN pip install -r requirements.txt
 # Edit Dockerfile here for installing necessary packages, copying files, etc.
 ######################
 RUN conda install pandas pyarrow bokeh
-RUN pip install pybaseball compbaseball==0.1.13
+RUN pip install pybaseball compbaseball
 ######################
 
 

--- a/docs/ENDPOINTS.md
+++ b/docs/ENDPOINTS.md
@@ -90,7 +90,7 @@ Warnings/Errors:
 
     The `jsonparams` data is displayed on the outputs page:
 
-    ![alt text](https://user-images.githubusercontent.com/9206065/50363064-3232ac80-0538-11e9-9eee-4f6dd8ab2238.png)
+    ![alt text](https://user-images.githubusercontent.com/9206065/50363819-60fe5200-053b-11e9-8b5c-e2eafe7f2668.png)
 
 Run simulation
 ----------------

--- a/docs/ENDPOINTS.md
+++ b/docs/ENDPOINTS.md
@@ -88,6 +88,10 @@ Warnings/Errors:
     Here's what you get after filling in this function:
     ![alt text](https://user-images.githubusercontent.com/9206065/50243758-0a0e4680-039c-11e9-9a98-56e2cbdd2f8f.png)
 
+    The `jsonparams` data is displayed on the outputs page:
+
+    ![alt text](https://user-images.githubusercontent.com/9206065/50363064-3232ac80-0538-11e9-9eee-4f6dd8ab2238.png)
+
 Run simulation
 ----------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ sendgrid-django
 pytest
 django-widget-tweaks
 django-crispy-forms
-compbaseball==0.1.13
+compbaseball

--- a/static/css/compbase.css
+++ b/static/css/compbase.css
@@ -172,3 +172,9 @@ input.model:not(:placeholder-shown) {
 .input-tooltip:hover {
   opacity: 0.5;
 }
+
+
+code {
+  color: inherit;
+  background-color: rgba(27,31,35,0.05);
+}

--- a/templates/core/corerun_detail.html
+++ b/templates/core/corerun_detail.html
@@ -83,8 +83,8 @@
             {% for sect, jsonobj in object.inputs.inputs_file.items %}
               <li>
               <ul class="list-unstyled">
-              <li><i> Inputs for section: <code>{{sect}}</code></i></li>
-              <li><code>{{jsonobj}}</code></li>
+              <li><p><i> Inputs for section: </i> <code>{{sect}}</code></p></li>
+              <li><pre><code>{{jsonobj}}</code></li></pre>
               </ul>
               </li>
             {% endfor %}

--- a/templates/core/corerun_detail.html
+++ b/templates/core/corerun_detail.html
@@ -157,10 +157,14 @@
           </div>
         {% endif %}
         </div>
-        <div class="row col-4" style="padding:10px">
-            <a href="{{ object.get_absolute_download_url }}/?raw_json=True" class="btn btn-block inverse-btn-match-nav">Download Raw Output</a>
+        <div class="container">
+          <div style="padding:10px;">
+            <a href="{{ object.get_absolute_download_url }}" class="btn btn-lg btn-match-nav w-50 mx-auto" style="display:block;padding:10px;">Download Results</a>
           </div>
-      </div>
+          <div style="padding:10px;">
+            <a href="{{ object.get_absolute_download_url }}/?raw_json=True" class="btn btn-sm inverse-btn-match-nav w-50 mx-auto" style="display:block;">Download raw JSON</a>
+          </div>
+        </div>
     </div>
   </div>
   <!-- <a class="btn btn-block btn-match-nav"

--- a/templates/core/corerun_detail.html
+++ b/templates/core/corerun_detail.html
@@ -75,11 +75,12 @@
   <br>
   <div id="table-drilldown-container">
     <div>
-      <div class="container">
-        <div class="row col-6" style="padding:10px">
-          <a href="{{ object.get_absolute_download_url }}" class="btn btn-block btn-match-nav">Download Results</a>
-        </div>
-        <div class="row">
+      <div class="container" style="padding:20px;">
+          <div class="container">
+              <div style="padding:10px;">
+                <a href="{{ object.get_absolute_download_url }}" class="btn btn-match-nav w-50 mx-auto" style="display:block;padding:10px;">Download Results</a>
+              </div>
+            <div class="row">
           {% if object.aggr_outputs %}
           <div class="col-md-12" id="aggr-totals-container">
             <div class="card">

--- a/templates/core/corerun_detail.html
+++ b/templates/core/corerun_detail.html
@@ -76,11 +76,25 @@
   <div id="table-drilldown-container">
     <div>
       <div class="container" style="padding:20px;">
+          <div class="container" style="padding:15px;">
+            <h1>{{result_header}}</h1>
+            <h4> The results were created with the inputs below: </h4>
+            <ul>
+            {% for sect, jsonobj in object.inputs.inputs_file.items %}
+              <li>
+              <ul class="list-unstyled">
+              <li><i> Inputs for section: <code>{{sect}}</code></i></li>
+              <li><code>{{jsonobj}}</code></li>
+              </ul>
+              </li>
+            {% endfor %}
+            <ul>
+          </div>
           <div class="container">
-              <div style="padding:10px;">
-                <a href="{{ object.get_absolute_download_url }}" class="btn btn-match-nav w-50 mx-auto" style="display:block;padding:10px;">Download Results</a>
-              </div>
-            <div class="row">
+            <div style="padding:10px;">
+              <a href="{{ object.get_absolute_download_url }}" class="btn btn-match-nav w-50 mx-auto" style="display:block;padding:10px;">Download Results</a>
+            </div>
+          <div class="row">
           {% if object.aggr_outputs %}
           <div class="col-md-12" id="aggr-totals-container">
             <div class="card">

--- a/webapp/apps/core/parser.py
+++ b/webapp/apps/core/parser.py
@@ -58,8 +58,9 @@ class Parser:
         unflattened = {}
         for sect, inputs in inputs_by_section.items():
             unflattened[sect] = self.unflatten(inputs)
-
-        return unflattened, "", {}
+        errors_warnings = {sect: {"errors": {}, "warnings": {}}
+                           for sect in inputs_by_section}
+        return unflattened, "", errors_warnings
 
     def unflatten(self, parsed_input):
         """

--- a/webapp/apps/core/submit.py
+++ b/webapp/apps/core/submit.py
@@ -67,7 +67,7 @@ class Submit:
                 errors_warnings,
             ) = parser.parse_parameters()
             self.model.upstream_parameters = upstream_parameters
-            self.model.input_file = upstream_json_files
+            self.model.inputs_file = upstream_json_files
             self.model.errors_warnings = errors_warnings
             self.model.save()
 

--- a/webapp/apps/core/tests/test_submit.py
+++ b/webapp/apps/core/tests/test_submit.py
@@ -1,3 +1,5 @@
+import json
+
 from django.test import RequestFactory
 
 from webapp.apps.core.submit import Submit, Save
@@ -23,6 +25,11 @@ def test_submit(core_inputs, meta_param, profile):
 
         def package_defaults(self):
             return core_inputs
+
+        def parse_parameters(self):
+            params, jsonstr, errors_warnings = super().parse_parameters()
+            jsonstr = json.dumps({"testing": [1, 2, 3]})
+            return params, jsonstr, errors_warnings
 
     class MockInputsForm(InputsForm):
         displayer_class = MockDisplayer
@@ -52,5 +59,8 @@ def test_submit(core_inputs, meta_param, profile):
     compute = MockCompute()
     submit = MockSubmit(request, compute)
     assert not submit.stop_submission
+    assert submit.model.upstream_parameters
+    assert submit.model.inputs_file
+    assert submit.model.errors_warnings
     save = MockSave(submit)
     assert save.runmodel_instance

--- a/webapp/apps/core/views.py
+++ b/webapp/apps/core/views.py
@@ -176,6 +176,11 @@ class OutputsView(SuperclassTemplateNameMixin, DetailView):
         return render(self.request, 'core/failed.html',
                       {"error_msg": self.object.error_text})
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["result_header"] = self.result_header
+        return context
+
     def dispatch(self, request, *args, **kwargs):
         compute = Compute()
         self.object = self.get_object()


### PR DESCRIPTION
This pr:

- Place a "Download Results" button at the bottom of the page beside the "Download raw JSON Outputs"
- centers up both sets of "Download Results" buttons.

<img width="1081" alt="screen shot 2018-12-21 at 12 29 26 pm" src="https://user-images.githubusercontent.com/9206065/50355651-6cdb1b80-051d-11e9-965b-f209ed29ea60.png">

<img width="1416" alt="screen shot 2018-12-21 at 12 39 21 pm" src="https://user-images.githubusercontent.com/9206065/50355664-78c6dd80-051d-11e9-9ddc-984085610823.png">
