### PR TITLE
Clean up package requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,6 @@ FROM heroku/miniconda:3
 ADD ./requirements.txt /requirements.txt
 ADD ./conda-requirements.txt /conda-requirements.txt
 
-# python version
-RUN python --version
-
 # Install dependencies
 RUN conda update conda
 RUN conda install -c anaconda --file conda-requirements.txt --yes

--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -1,1 +1,2 @@
+pip
 pandas

--- a/distributed/dockerfiles/Dockerfile
+++ b/distributed/dockerfiles/Dockerfile
@@ -7,6 +7,7 @@ RUN mkdir /home/distributed
 RUN mkdir /home/distributed/api
 COPY requirements.txt home/distributed
 
+RUN conda update conda
 RUN conda config --append channels conda-forge
 RUN conda install python=3.6
 

--- a/distributed/requirements.txt
+++ b/distributed/requirements.txt
@@ -1,3 +1,4 @@
+pip
 msgpack
 celery
 redis==2.10.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 django>=2.1.2
 msgpack
-requests
+requests>=2.20
 requests_mock
 dj_database_url
 dataclasses
@@ -13,3 +13,4 @@ pytest
 django-widget-tweaks
 django-crispy-forms
 compbaseball
+psycopg2-binary


### PR DESCRIPTION
This PR:
- ensures that an up-to-date version of `pip` is installed; by default `conda` installs `pip` version 0.9 while the up-to-date version is 0.18
- installs `psycopg2-binary` which gets rid of the following warning:
  ```
  UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use "pip install psycopg2-binary" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.
  ```
- installs `requests>=2.20` which is the minimum version required by the Stripe python package.