### PR TITLE
Update schema for ParamTools data format

### DIFF
--- a/docs/ENDPOINTS.md
+++ b/docs/ENDPOINTS.md
@@ -30,23 +30,23 @@ COMP will provide parsed user adjustments of the form:
 ```json
 {
     "matchup": {
-        "start_date": "2012-08-01",
-        "end_date": "2012-09-01",
-        "pitcher": "Not a Real Pitcher",
+        "start_date": [{"value": "2012-08-01"}],
+        "end_date": [{"value": "2012-09-01"}],
+        "pitcher": [{"value": "Not a Real Pitcher"}],
     }
 }
 ```
 
 The function should return:
 
-Reformatted data (no reformatting necessary for this project):
+Potentially, reformatted data (no reformatting necessary for this project):
 
 ```json
 {
     "matchup": {
-        "start_date": "2012-08-01",
-        "end_date": "2012-09-01",
-        "pitcher": "Not a Real Pitcher",
+        "start_date": [{"value": "2012-08-01"}],
+        "end_date": [{"value": "2012-09-01"}],
+        "pitcher": [{"value": "Not a Real Pitcher"}],
     }
 }
 ```
@@ -55,7 +55,7 @@ JSON representation of each major section of parameters:
 
 ```python
     {
-        "matchup":  '{"start_date": "2012-08-01", "end_date": "2012-09-01", "pitcher": "Not a Real Pitcher"}'
+        "matchup": '{"start_date": [{"value": "2012-08-01"}], "end_date": [{"value": "2012-09-01"}], "pitcher": [{"value": "Not a Real Pitcher"}]}'
     }
 ```
 
@@ -65,7 +65,7 @@ Warnings/Errors:
     {
         "matchup": {
             "errors": {
-                "pitcher": "Pitcher \"Not a Real Pitcher\" not allowed"
+                "pitcher": ["Pitcher \"Not a Real Pitcher\" not allowed"]
             },
             "warnings": {}
         }

--- a/docs/IOSCHEMA.md
+++ b/docs/IOSCHEMA.md
@@ -1,6 +1,6 @@
 # Input-Output Schema
 
-COMP relies on three primary JSON schemas: Meta Parameters, Model Parameters, and Outputs. COMP uses them to derive the COMP input form representing your model's default specification and your model's output page. One of the required Python functions in the next step of this guide will also rely on these scheme to validate user adjustments on the COMP input form.
+COMP relies on three primary JSON schemas: Meta Parameters, Model Parameters, and Outputs. COMP uses them to derive the COMP input form representing your model's default specification and your model's output page. One of the required Python functions in the next step of this guide will also rely on these schemas to validate user adjustments on the COMP input form. The [ParamTools][3] project is compatible with the inputs schemas below and can be used for the parameter processing and validation that is described in the Python functions documentation.
 
 Meta Parameters
 --------------------------------
@@ -165,4 +165,4 @@ JSON Objects
 
 [1]: https://github.com/PSLmodels/Tax-Calculator
 [2]: https://github.com/hdoupe/ParamProject
-
+[3]: https://github.com/PSLmodels/ParamTools

--- a/docs/IOSCHEMA.md
+++ b/docs/IOSCHEMA.md
@@ -52,7 +52,7 @@ COMP uses the JSON schema below for documenting Model Parameters and their value
   - `"str"` - String.
   - `"date"`- Date. Needs to be of the format `"YYYY-MM-DD"`.
 - "value": A list of [Value Objects](#value-object). Describes the default values of the parameter.
-- "validators": A Mapping of [Validator Objects](#validator-object).
+- "validators": A mapping of [Validator Objects](#validator-object).
 
 Example:
 

--- a/docs/IOSCHEMA.md
+++ b/docs/IOSCHEMA.md
@@ -1,60 +1,85 @@
 # Input-Output Schema
 
-COMP relies on three primary JSON schemas: Meta Parameters, Model Parameters, and Outputs. COMP uses them to derive the COMP input form representing your model's default specification and your model's output page. One of the required Python functions in the next step of this guide will also rely on these scheme to validate user adjustments on the COMP input form. 
+COMP relies on three primary JSON schemas: Meta Parameters, Model Parameters, and Outputs. COMP uses them to derive the COMP input form representing your model's default specification and your model's output page. One of the required Python functions in the next step of this guide will also rely on these scheme to validate user adjustments on the COMP input form.
 
 Meta Parameters
 --------------------------------
 
 These are the parameters upon which Model Parameters depend. For example, if your model's default Model Parameters depend on the dataset being used, a meta parameter named `data_set` could be helfpul. This should be of the form:
 
+- "variable_name": The name of the meta parameter as it is used in the modeling project.
+- "title": A human readable name for the parameter.
+- "default": A default value for the meta parameter.
+- "type": The parameter's data type. Supported types are:
+  - "int": Integer.
+  - "float": Floating point.
+  - "bool": Boolean. Either `True` or `False`.
+  - "str"`: String.
+  - "date": Date. Needs to be of the format `"YYYY-MM-DD"`.
+- "validators": A mapping of [Validator Objects](#validator-object).
+
+Example:
+
 ```json
 {
-    "variable_name": {
-        "title": "Variable Name",
-        "default": "default value",
-        "type": "int, boolean, string, date",
+    "time_of_day": {
+        "title": "Time of the Day",
+        "default": 12,
+        "type": "int",
         "validators": {
-            "range": {"min": "minvalue", "max": "maxvalue"},
-            "choices": {"choices": ["list of choices"]}
+            "range": {"min": 0, "max": 23}
         }
     }
 }
 ```
-
-Notes:
-- Supported types are `"int"`, `"float"`, `"bool"`, `"str"`, and `"date"`. Parameters of type `"date"` expect the format `"YYYY-MM-DD"`.
-- Validators are optional. More validators will be added in the future.
 
 Model Parameters
 ----------------
 
 COMP uses the JSON schema below for documenting Model Parameters and their values under the default sepcification:
 
+- "major_section": Broad categories of model parameters. A baseball model may break up its model parameters into Hitting, Pitching, and Fielding major sections.
+- "param_name": The name of the parameter as it is used in the modeling project.
+- "title": A human readable name for the parameter.
+- "description": Describes this parameter.
+- "notes": Any additional information that should be displayed to the user.
+- "section_1": Section of parameters that are like this one
+- "section_2": Subsection of section 1.
+- "type": The parameter's data type. Supported types are:
+  - `"int"` - Integer.
+  - `"float"`- Floating point.
+  - `"bool"`- Boolean. Either `True` or `False`.
+  - `"str"` - String.
+  - `"date"`- Date. Needs to be of the format `"YYYY-MM-DD"`.
+- "value": A list of [Value Objects](#value-object). Describes the default values of the parameter.
+- "validators": A Mapping of [Validator Objects](#validator-object).
+
+Example:
+
 ```json
 {
-    "majorsection1": {
-        "param_name1": {
-            "long_name": "Human Readable Name of Parameter",
-            "description": "Description of this parameter",
-            "section_1": "Section of parameters that are like this one",
-            "section_2": "Subsection of section 1",
-            "notes": "More notes on this parameter.",
-            "type": "type here",
-            "value": "value here",
+    "weather": {
+        "temperature": {
+            "title": "Temperature",
+            "description": "Temperature at a given hour in the day",
+            "section_1": "Hourly Weather",
+            "section_2": "Standard Measurements",
+            "notes": "This is in Fahrenheit.",
+            "type": "int",
+            "value": [
+                {"time_of_day": 0, "value": 40},
+                {"time_of_day": 8, "value": 38},
+                {"time_of_day": 16, "value": 50}
+            ],
             "validators": {
-                "range": {"min": "minvalue", "max": "maxvalue"},
-                "choice": {"min": "minvalue", "max": "maxvalue"}
+                "range": {"min": -130, "max": 135}
             }
         }
-    },
-    "majorsection2": {
     }
 }
 ```
 
-Notes:
-- The major sections can be thought of as broad categories of model parameters. A baseball model may break up its model parameters into Hitting, Pitching, and Fielding major sections.
-- Supported types are `"int"`, `"float"`, `"bool"`, `"str"`, and `"date"`. Parameters of type `"date"` expect the format `"YYYY-MM-DD"`.
+
 
 Outputs
 ------------
@@ -105,5 +130,39 @@ The Outputs Schema:
 }
 ```
 
+JSON Objects
+---------------
+
+### Validator Object
+- Used for validating user input.
+- Available validators:
+  - "range": Define a minimum and maximum value for a given parameter.
+    - Arguments:
+      - "min": Minimum allowed value.
+      - "max": Maximum allowed value.
+    - Example:
+        ```json
+        {
+            "range": {"min": 0, "max": 10}
+        }
+        ```
+  - "choice": Define a set of values that this parameter can take.
+    - Arguments:
+      - "choice": List of allowed values.
+    - Example:
+        ```json
+        {
+            "choice": {"choices": ["allowed choice", "another allowed choice"]}
+        }
+        ```
+
+### Value Object
+- Used for defining the value of a parameter. The Value Object consists of a "value" attribute indicating the parameter's value and zero or more key-value pairs that describe the dimensions of the parameter space that the value should be applied to.
+- Example:
+    ```json
+    {"time_of_day": 0, "value": 40},
+    ```
+
 [1]: https://github.com/PSLmodels/Tax-Calculator
 [2]: https://github.com/hdoupe/ParamProject
+


### PR DESCRIPTION
This PR updates the recommended data format to match the format used by [ParamTools][1]. I also drew some inspiration from the [Mozilla WOT data format documentation][2] and re-organized some of the Input-Output Schema documentation to follow that documentation style.

[1]: https://github.com/PSLmodels/ParamTools
[2]: https://iot.mozilla.org/wot/