### PR TITLE
Clean up `billing.json` file and save sponsor on Save class

### DIFF
--- a/webapp/apps/billing/billing.json
+++ b/webapp/apps/billing/billing.json
@@ -1,18 +1,4 @@
 {
-    "mock": {
-        "name": "Used strictly for testing",
-        "sponsor": null,
-        "username": null,
-        "amount": 0,
-        "metered_amount": 1,
-        "currency": "usd",
-        "interval": "month",
-        "trial_days": 0,
-        "server_cost": 0.10,
-        "exp_task_time": 20,
-        "exp_num_tasks": 5,
-        "is_public": false
-    },
     "matchups": {
         "name": "Matchups",
         "sponsor": "hdoupe",

--- a/webapp/apps/billing/management/commands/init_projects.py
+++ b/webapp/apps/billing/management/commands/init_projects.py
@@ -15,10 +15,18 @@ class Command(BaseCommand):
             dest='use_stripe',
             help='Use stripe when initializing the database',
         )
+        parser.add_argument(
+            '--include_mock_data',
+            action='store_true',
+            dest='include_mock_data',
+            help='Include mock data. Used for testing.',
+        )
+
 
     def handle(self, *args, **options):
         use_stripe = options["use_stripe"]
-        billing = get_billing_data()
+        include_mock_data = options["include_mock_data"]
+        billing = get_billing_data(include_mock_data=options["include_mock_data"])
         for app_name, plan in billing.items():
             if plan["username"]:
                 try:

--- a/webapp/apps/billing/tests/mock-billing.json
+++ b/webapp/apps/billing/tests/mock-billing.json
@@ -1,0 +1,30 @@
+{
+    "mock": {
+        "name": "Used for testing",
+        "sponsor": null,
+        "username": null,
+        "amount": 0,
+        "metered_amount": 1,
+        "currency": "usd",
+        "interval": "month",
+        "trial_days": 0,
+        "server_cost": 0.10,
+        "exp_task_time": 20,
+        "exp_num_tasks": 5,
+        "is_public": false
+    },
+    "sponsor-mock": {
+        "name": "Used for testing sponsored apps",
+        "sponsor": "sponsor",
+        "username": null,
+        "amount": 0,
+        "metered_amount": 1,
+        "currency": "usd",
+        "interval": "month",
+        "trial_days": 0,
+        "server_cost": 0.10,
+        "exp_task_time": 20,
+        "exp_num_tasks": 5,
+        "is_public": false
+    }
+}

--- a/webapp/apps/billing/tests/test_models.py
+++ b/webapp/apps/billing/tests/test_models.py
@@ -35,7 +35,7 @@ class TestStripeModels():
         assert not customer.livemode
 
     def test_construct(self):
-        billing = get_billing_data()
+        billing = get_billing_data(include_mock_data=True)
         assert 'mock' in billing
         products = Product.objects.all()
         assert len(products) == len(billing)

--- a/webapp/apps/billing/utils.py
+++ b/webapp/apps/billing/utils.py
@@ -8,10 +8,13 @@ from .models import SubscriptionItem, UsageRecord
 USE_STRIPE = os.environ.get("USE_STRIPE", "false").lower() == "true"
 
 
-def get_billing_data():
+def get_billing_data(include_mock_data=False):
     path = os.path.abspath(os.path.dirname(__file__))
     with open(os.path.join(path, 'billing.json')) as f:
         billing = json.loads(f.read())
+    if include_mock_data:
+        with open(os.path.join(path, 'tests', 'mock-billing.json')) as f:
+            billing.update(json.loads(f.read()))
     return billing
 
 
@@ -30,8 +33,10 @@ class ChargeRunMixin:
                 self.object.run_time, adjust=True)
             plan = self.object.project.product.plans.get(
                 usage_type='metered')
+            # The sponsor is also stored on the CoreRun object. However, the
+            # Project object should be considered the single source of truth
+            # for sending usage records.
             sponsor = self.object.project.sponsor
-            self.object.sponsor = sponsor
             if sponsor is not None:
                 customer = sponsor.user.customer
             else:

--- a/webapp/apps/conftest.py
+++ b/webapp/apps/conftest.py
@@ -11,7 +11,7 @@ from django.contrib.auth import get_user_model
 from webapp.apps.billing.models import (Customer, Plan, Subscription,
                                         SubscriptionItem)
 from webapp.apps.billing.utils import USE_STRIPE, get_billing_data
-from webapp.apps.users.models import Profile
+from webapp.apps.users.models import Profile, Project
 
 from webapp.apps.core.meta_parameters import MetaParameter, MetaParameters
 
@@ -23,8 +23,9 @@ stripe.api_key = os.environ.get('STRIPE_SECRET')
 @pytest.fixture(scope='session')
 def django_db_setup(django_db_setup, django_db_blocker):
     with django_db_blocker.unblock():
-        call_command("init_projects", use_stripe=USE_STRIPE)
-        for name, proj in get_billing_data().items():
+        call_command("init_projects", use_stripe=USE_STRIPE,
+                     include_mock_data=True)
+        for name, proj in get_billing_data(include_mock_data=True).items():
             if proj["sponsor"] is None:
                 continue
             else:
@@ -41,9 +42,10 @@ def django_db_setup(django_db_setup, django_db_blocker):
                     customer_user = customer.user
                 else:
                     customer_user = user
-                    Profile.objects.create(user=customer_user,
+                Profile.objects.create(user=customer_user,
                                         is_active=True)
-        call_command("init_projects", use_stripe=USE_STRIPE)
+        call_command("init_projects", use_stripe=USE_STRIPE,
+                     include_mock_data=True)
 
 @pytest.fixture
 def stripe_customer():
@@ -99,7 +101,7 @@ def profile(db, user):
 
 @pytest.fixture
 def plans(db):
-    plans = Plan.objects.filter(product__name='Used strictly for testing')
+    plans = Plan.objects.filter(product__name='Used for testing')
     return plans
 
 

--- a/webapp/apps/core/submit.py
+++ b/webapp/apps/core/submit.py
@@ -143,7 +143,7 @@ class Save:
         runmodel.inputs = submit.model
         runmodel.profile = getattr(submit.request.user, "profile", None)
         runmodel.project = Project.objects.get(name=self.project_name)
-
+        runmodel.sponsor = runmodel.project.sponsor
         runmodel.upstream_vers = submit.upstream_version
         runmodel.webapp_vers = submit.webapp_version
 


### PR DESCRIPTION
This PR:
- Move test data from `billing.json` to `tests/mock-billing.json`. 
- Set sponsor for the model run in the `Save` class. Other similar attributes are saved there, such as the profile of the user who kicked off the run.