### PR TITLE
Add field for choice parameters

### DIFF
--- a/static/js/core.js
+++ b/static/js/core.js
@@ -17,4 +17,15 @@ $(document).ready(function(){
     }
   });
 
-})
+  $('select.form-control').change(function(e) {
+    console.log($(this));
+    $(this).removeClass("unedited");
+  });
+
+  $('#inputs-form').submit(function(e) {
+    $(".unedited.select.form-control").each(function() {
+      select = $(this);
+      select.prop("disabled", true);
+    });
+  });
+});

--- a/webapp/apps/contrib/ptstyle/param.py
+++ b/webapp/apps/contrib/ptstyle/param.py
@@ -22,9 +22,12 @@ class Value:
         self.number_dims = number_dims
         if self.number_dims == 0 and "choice" in validators:
             choices_ = validators["choice"]["choices"]
-            dv_ix = choices_.remove(self.default_value)
-            choices_.insert(0, self.default_value)
-            choices = [(c, c) for c in choices_]
+            if len(choices) < 25:
+                dv_ix = choices_.remove(self.default_value)
+                choices_.insert(0, self.default_value)
+                choices = [(c, c) for c in choices_]
+            else:
+                choices = None
         else:
             choices = None
         if isinstance(self.default_value, list):

--- a/webapp/apps/contrib/ptstyle/param.py
+++ b/webapp/apps/contrib/ptstyle/param.py
@@ -1,9 +1,8 @@
-from webapp.apps.core.param import Param, Value, SeparatedValue
+from webapp.apps.core.param import Param, Value
 from .utils import dims_to_string
 
 
 class ParamToolsParam(Param):
-
     def set_fields(self, value, **field_kwargs):
         """
         Value is of the shape:
@@ -16,22 +15,19 @@ class ParamToolsParam(Param):
         -
 
         """
-        if self.number_dims == 0:
-            self.field_class = Value
-        else:
-            self.field_class = SeparatedValue
-
         for value_object in value:
             field_name, suffix = dims_to_string(
-                self.name, value_object, self.meta_parameters)
+                self.name, value_object, self.meta_parameters
+            )
             label = self.format_label(value_object)
             field = self.field_class(
                 field_name,
                 label,
                 value_object["value"],
                 self.coerce_func,
-                1,
-                **field_kwargs
+                self.number_dims,
+                self.attributes.get("validators", {}),
+                **field_kwargs,
             )
             self.fields[field_name] = field.form_field
             self.col_fields.append(field)

--- a/webapp/apps/contrib/ptstyle/param.py
+++ b/webapp/apps/contrib/ptstyle/param.py
@@ -1,8 +1,70 @@
+from django import forms
+
 from webapp.apps.core.param import Param, Value
+from webapp.apps.core.fields import ValueField, SeparatedValueField
 from .utils import dims_to_string
 
 
+class Value:
+    def __init__(
+        self,
+        name,
+        label,
+        default_value,
+        coerce_func,
+        number_dims,
+        validators,
+        **field_kwargs,
+    ):
+        self.name = name
+        self.label = label
+        self.default_value = default_value
+        self.number_dims = number_dims
+        if self.number_dims == 0 and "choice" in validators:
+            choices_ = validators["choice"]["choices"]
+            dv_ix = choices_.remove(self.default_value)
+            choices_.insert(0, self.default_value)
+            choices = [(c, c) for c in choices_]
+        else:
+            choices = None
+        if isinstance(self.default_value, list):
+            self.default_value = ", ".join([str(v) for v in self.default_value])
+        attrs = {"placeholder": self.default_value}
+        if self.number_dims == 0:
+            if choices is not None:
+                attrs["class"] = "unedited"
+                self.form_field = forms.TypedChoiceField(
+                    label=self.label,
+                    required=False,
+                    initial=self.default_value,
+                    widget=forms.Select(attrs=attrs),
+                    coerce=coerce_func,
+                    choices=choices,
+                    **field_kwargs,
+                )
+            else:
+                self.form_field = ValueField(
+                    label=self.label,
+                    widget=forms.TextInput(attrs=attrs),
+                    required=False,
+                    coerce=coerce_func,
+                    number_dims=number_dims,
+                    **field_kwargs,
+                )
+        else:
+            self.form_field = SeparatedValueField(
+                label=self.label,
+                widget=forms.TextInput(attrs=attrs),
+                required=False,
+                coerce=coerce_func,
+                number_dims=number_dims,
+                **field_kwargs,
+            )
+
+
 class ParamToolsParam(Param):
+    field_class = Value
+
     def set_fields(self, value, **field_kwargs):
         """
         Value is of the shape:

--- a/webapp/apps/contrib/ptstyle/tests/defaults.json
+++ b/webapp/apps/contrib/ptstyle/tests/defaults.json
@@ -104,5 +104,22 @@
         "out_of_range_minmsg": "",
         "out_of_range_maxmsg": "",
         "out_of_range_action": "stop"
+    },
+    "int_array_param": {
+        "title": "integer array parameter",
+        "description": "Serves as array reference variable.",
+        "notes": "",
+        "section_1": "",
+        "section_2": "",
+        "opt0": "an option",
+        "type": "int",
+        "number_dims": 1,
+        "value": [
+            {"dim0": "zero", "dim1": 1, "value": [1, 2, 3]}
+        ],
+        "validators": {"range": {"min": 0, "max": 10}},
+        "out_of_range_minmsg": "",
+        "out_of_range_maxmsg": "",
+        "out_of_range_action": "stop"
     }
 }

--- a/webapp/apps/contrib/taxcalcstyle/param.py
+++ b/webapp/apps/contrib/taxcalcstyle/param.py
@@ -38,7 +38,6 @@ class TaxcalcStyleParam(BaseParam):
                 value[dim1],
                 self.coerce_func,
                 0,
-                {},
                 **field_kwargs,
             )
             self.fields[field_name] = field.form_field

--- a/webapp/apps/contrib/taxcalcstyle/param.py
+++ b/webapp/apps/contrib/taxcalcstyle/param.py
@@ -1,24 +1,25 @@
 from webapp.apps.core.param import CheckBox, BaseParam
 from webapp.apps.core.fields import coerce_bool, coerce_float, coerce_int
 
-class TaxcalcStyleParam(BaseParam):
 
+class TaxcalcStyleParam(BaseParam):
     def __init__(self, name, attributes, **meta_parameters):
         super().__init__(name, attributes, **meta_parameters)
         if "compatible_data" in attributes:
             self.gray_out = not (
-                (attributes["compatible_data"]["cps"] and
-                 self.data_source == "CPS")
-                or (attributes["compatible_data"]["puf"] and
-                    self.data_source == "PUF"))
+                (attributes["compatible_data"]["cps"] and self.data_source == "CPS")
+                or (attributes["compatible_data"]["puf"] and self.data_source == "PUF")
+            )
         else:
             # if compatible_data is not specified do not gray out
             self.gray_out = False
-        self.info = " ".join([
-            attributes['description'],
-            attributes.get('irs_ref') or "",
-            attributes.get('notes') or ""
-        ]).strip()
+        self.info = " ".join(
+            [
+                attributes["description"],
+                attributes.get("irs_ref") or "",
+                attributes.get("notes") or "",
+            ]
+        ).strip()
         field_kwargs = {"disabled": self.gray_out}
         self.set_fields(self.default_value, **field_kwargs)
 
@@ -37,7 +38,8 @@ class TaxcalcStyleParam(BaseParam):
                 value[dim1],
                 self.coerce_func,
                 0,
-                **field_kwargs
+                {},
+                **field_kwargs,
             )
             self.fields[field_name] = field.form_field
             self.col_fields.append(field)
@@ -48,10 +50,8 @@ class TaxcalcStyleParam(BaseParam):
         if self.inflatable:
             field_name = f"{self.name}_cpi"
             self.cpi_field = CheckBox(
-                field_name,
-                "CPI",
-                self.attributes['cpi_inflated'],
-                **field_kwargs)
+                field_name, "CPI", self.attributes["cpi_inflated"], **field_kwargs
+            )
             self.fields[field_name] = self.cpi_field.form_field
 
     def get_coerce_func(self):

--- a/webapp/apps/core/param.py
+++ b/webapp/apps/core/param.py
@@ -1,61 +1,79 @@
 from django import forms
 
-from .fields import (ValueField, SeparatedValueField, coerce_bool,
-                     coerce_float, coerce_int, coerce_date, coerce)
-
-
-class SeparatedValue:
-
-    def __init__(self, name, label, default_value, coerce_func, number_dims,
-                 **field_kwargs):
-        self.name = name
-        self.label = label
-        self.default_value = default_value
-        if isinstance(self.default_value, list):
-            self.default_value = ', '.join([str(v) for v in self.default_value])
-        attrs = {
-            'class': 'form-control',
-            'placeholder': self.default_value,
-        }
-        self.form_field = SeparatedValueField(
-            label=self.label,
-            widget=forms.TextInput(attrs=attrs),
-            required=False,
-            coerce=coerce_func,
-            number_dims=number_dims,
-            **field_kwargs
-        )
+from .fields import (
+    ValueField,
+    SeparatedValueField,
+    coerce_bool,
+    coerce_float,
+    coerce_int,
+    coerce_date,
+    coerce,
+)
 
 
 class Value:
-
-    def __init__(self, name, label, default_value, coerce_func, number_dims,
-                 **field_kwargs):
+    def __init__(
+        self,
+        name,
+        label,
+        default_value,
+        coerce_func,
+        number_dims,
+        validators,
+        **field_kwargs
+    ):
         self.name = name
         self.label = label
         self.default_value = default_value
-        attrs = {
-            'class': 'form-control',
-            'placeholder': self.default_value,
-        }
-        self.form_field = ValueField(
-            label=self.label,
-            widget=forms.TextInput(attrs=attrs),
-            required=False,
-            coerce=coerce_func,
-            number_dims=number_dims,
-            **field_kwargs
-        )
+        self.number_dims = number_dims
+        if self.number_dims == 0 and "choice" in validators:
+            choices_ = validators["choice"]["choices"]
+            dv_ix = choices_.remove(self.default_value)
+            choices_.insert(0, self.default_value)
+            choices = [(c, c) for c in choices_]
+        else:
+            choices = None
+        if isinstance(self.default_value, list):
+            self.default_value = ", ".join([str(v) for v in self.default_value])
+        attrs = {"placeholder": self.default_value}
+        if self.number_dims == 0:
+            if choices is not None:
+                attrs["class"] = "unedited"
+                self.form_field = forms.TypedChoiceField(
+                    label=self.label,
+                    required=False,
+                    initial=self.default_value,
+                    widget=forms.Select(attrs=attrs),
+                    coerce=coerce_func,
+                    choices=choices,
+                    **field_kwargs
+                )
+            else:
+                self.form_field = ValueField(
+                    label=self.label,
+                    widget=forms.TextInput(attrs=attrs),
+                    required=False,
+                    coerce=coerce_func,
+                    number_dims=number_dims,
+                    **field_kwargs
+                )
+        else:
+            self.form_field = SeparatedValueField(
+                label=self.label,
+                widget=forms.TextInput(attrs=attrs),
+                required=False,
+                coerce=coerce_func,
+                number_dims=number_dims,
+                **field_kwargs
+            )
+
 
 class CheckBox:
-
     def __init__(self, name, label, default_value, **field_kwargs):
         self.name = name
         self.label = label
         self.default_value = default_value
-        attrs = {
-            'placeholder': str(self.default_value),
-        }
+        attrs = {"placeholder": str(self.default_value)}
         self.form_field = forms.NullBooleanField(
             label=self.label,
             widget=forms.TextInput(attrs=attrs),
@@ -66,7 +84,7 @@ class CheckBox:
 
 class BaseParam:
 
-    field_class = SeparatedValue
+    field_class = Value
 
     type_map = {
         "int": coerce_int,
@@ -80,8 +98,7 @@ class BaseParam:
         self.name = name
         self.attributes = attributes
         # title is preferred, but long_name is also acceptable.
-        self.title = (self.attributes.get("title", None) or
-                      self.attributes["long_name"])
+        self.title = self.attributes.get("title", None) or self.attributes["long_name"]
         self.description = self.attributes["description"]
         self.number_dims = self.attributes.get("number_dims", 1)
         self.col_fields = []
@@ -91,24 +108,20 @@ class BaseParam:
         self.coerce_func = self.get_coerce_func()
         self.default_value = self.attributes["value"]
 
-        self.info = " ".join([
-            attributes['description'],
-            attributes.get('notes') or ""
-        ]).strip()
+        self.info = " ".join(
+            [attributes["description"], attributes.get("notes") or ""]
+        ).strip()
 
         self.fields = {}
 
     def set_fields(self, value, **field_kwargs):
-        if self.number_dims == 0:
-            self.field_class = Value
-        else:
-            self.field_class = SeparatedValue
         field = self.field_class(
             self.name,
-            '',
+            "",
             value,
             self.coerce_func,
             self.number_dims,
+            self.attributes.get("validators", {}),
             **field_kwargs
         )
         self.fields[self.name] = field.form_field
@@ -120,7 +133,6 @@ class BaseParam:
 
 
 class Param(BaseParam):
-
     def __init__(self, name, attributes, **meta_parameters):
         super().__init__(name, attributes, **meta_parameters)
         self.set_fields(self.default_value)

--- a/webapp/apps/core/param.py
+++ b/webapp/apps/core/param.py
@@ -13,50 +13,24 @@ from .fields import (
 
 class Value:
     def __init__(
-        self,
-        name,
-        label,
-        default_value,
-        coerce_func,
-        number_dims,
-        validators,
-        **field_kwargs
+        self, name, label, default_value, coerce_func, number_dims, **field_kwargs
     ):
         self.name = name
         self.label = label
         self.default_value = default_value
         self.number_dims = number_dims
-        if self.number_dims == 0 and "choice" in validators:
-            choices_ = validators["choice"]["choices"]
-            dv_ix = choices_.remove(self.default_value)
-            choices_.insert(0, self.default_value)
-            choices = [(c, c) for c in choices_]
-        else:
-            choices = None
         if isinstance(self.default_value, list):
             self.default_value = ", ".join([str(v) for v in self.default_value])
         attrs = {"placeholder": self.default_value}
         if self.number_dims == 0:
-            if choices is not None:
-                attrs["class"] = "unedited"
-                self.form_field = forms.TypedChoiceField(
-                    label=self.label,
-                    required=False,
-                    initial=self.default_value,
-                    widget=forms.Select(attrs=attrs),
-                    coerce=coerce_func,
-                    choices=choices,
-                    **field_kwargs
-                )
-            else:
-                self.form_field = ValueField(
-                    label=self.label,
-                    widget=forms.TextInput(attrs=attrs),
-                    required=False,
-                    coerce=coerce_func,
-                    number_dims=number_dims,
-                    **field_kwargs
-                )
+            self.form_field = ValueField(
+                label=self.label,
+                widget=forms.TextInput(attrs=attrs),
+                required=False,
+                coerce=coerce_func,
+                number_dims=number_dims,
+                **field_kwargs
+            )
         else:
             self.form_field = SeparatedValueField(
                 label=self.label,
@@ -116,13 +90,7 @@ class BaseParam:
 
     def set_fields(self, value, **field_kwargs):
         field = self.field_class(
-            self.name,
-            "",
-            value,
-            self.coerce_func,
-            self.number_dims,
-            self.attributes.get("validators", {}),
-            **field_kwargs
+            self.name, "", value, self.coerce_func, self.number_dims, **field_kwargs
         )
         self.fields[self.name] = field.form_field
         self.col_fields.append(field)


### PR DESCRIPTION
This PR adds a choice field. A choice field is used for parameters that have zero dimensions and utilize the ["choice" validator][1] in the ParamTools schema. 

<img width="421" alt="screen shot 2019-02-04 at 4 13 50 pm" src="https://user-images.githubusercontent.com/9206065/52238151-56084280-2899-11e9-96ff-99dc52b02145.png">
<img width="460" alt="screen shot 2019-02-04 at 4 13 59 pm" src="https://user-images.githubusercontent.com/9206065/52238152-56084280-2899-11e9-887c-b9172c8c1ba7.png">


[1]: https://github.com/pslmodels/paramtools#validator-object