### PR TITLE
Rework meta parameter section presentation

### DIFF
--- a/templates/core/inputs/metaparameters.html
+++ b/templates/core/inputs/metaparameters.html
@@ -7,6 +7,9 @@
     <div class="container">
       <h1>
         {{ title }}
+        <label>
+          {% include 'core/inputs/fields/tooltip.html' with text="These are the parameters upon which the Model Parameters below depend." %}
+        </label>
         <div class="float-right">
           <button
             class="btn collapse-button"

--- a/templates/core/inputs/metaparameters.html
+++ b/templates/core/inputs/metaparameters.html
@@ -38,7 +38,7 @@
                       type="submit"
                       name="reset"
                       value="true"
-                      style="margin:10px;margin-left:0px;">Reset default parameters
+                      style="margin:10px;margin-left:0px;">Reset default parameters with updated meta parameters
                     </button>
                 </li>
             </ul>

--- a/templates/core/inputs/metaparameters.html
+++ b/templates/core/inputs/metaparameters.html
@@ -8,7 +8,7 @@
       <h1>
         {{ title }}
         <label>
-          {% include 'core/inputs/fields/tooltip.html' with text="These are the parameters upon which the Model Parameters below depend." %}
+          {% include 'core/inputs/fields/tooltip.html' with text="These are the parameters upon which the Model Parameters below depend. Changing the value of one of the meta parameters may change the default value(s) of some of the Model Parameters." %}
         </label>
         <div class="float-right">
           <button
@@ -38,7 +38,7 @@
                       type="submit"
                       name="reset"
                       value="true"
-                      style="margin:10px;margin-left:0px;">Reset default parameters with updated meta parameters
+                      style="margin:10px;margin-left:0px;">Reset with updated meta parameters
                     </button>
                 </li>
             </ul>


### PR DESCRIPTION
The goal of this PR is to clear up some of the confusion around meta parameters. This PR adds an info box and changes the label on the meta parameters reset button. I'm interested in others thoughts about how this information can more clearly be conveyed to the user.

![screen shot 2019-02-04 at 5 07 15 pm](https://user-images.githubusercontent.com/9206065/52240644-68857a80-289f-11e9-9d9f-6babf44cad74.png)
![screen shot 2019-02-04 at 5 07 27 pm](https://user-images.githubusercontent.com/9206065/52240645-691e1100-289f-11e9-95bb-e1c744d87534.png)
