### PR TITLE
Add tax-brain to the models dropdown menu

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -30,6 +30,7 @@
                 <div class="dropdown-menu" aria-labelledby="navbarDropdown">
                   <!-- Add new projects to the dropdown menu here! -->
                   <a class="dropdown-item" href="/hdoupe/Matchups">hdoupe/Matchups</a>
+                  <a class="dropdown-item" href="/PSLmodels/Tax-Brain">PSLmodels/Tax-Brain</a>
                 </div>
             </li>
             <li>


### PR DESCRIPTION
I forgot to do this in PR #76. Once PR #68 is merged, this step will no longer be necessary.