### PR TITLE
Fix sim does not exist error and edit page error

### DIFF
--- a/templates/comp/inputs_form.html
+++ b/templates/comp/inputs_form.html
@@ -63,7 +63,7 @@
           <div class="modal-content">
             <div class="modal-header">
               <h5 class="modal-title" id="submitModalLabel">
-                {% if can_run %}
+                {% if user_can_run %}
                   Are you sure that you want to run this simulation?
                 {% else %}
                   {% if not user.is_authenticated %}
@@ -78,7 +78,7 @@
               </button>
             </div>
             <div class="modal-body">
-              {% if can_run %}
+              {% if user_can_run %}
                 {% if provided_free %}
                   This model's simulations are sponsored and thus, are free for you.
                 {% else %}
@@ -100,7 +100,7 @@
             </div>
             <div class="modal-footer">
               <button type="button" class="btn btn-outline-secondary" data-dismiss="modal">Close</button>
-              {% if can_run %}
+              {% if user_can_run %}
                 <button type="submit" name="full_calc" value="true" class="btn btn-success">Run simulation</button>
               {% else %}
                 {% if not user.is_authenticated %}

--- a/templates/comp/pricing_collapse.html
+++ b/templates/comp/pricing_collapse.html
@@ -14,7 +14,7 @@
       {% if provided_free %}
         <p> This model is provided for free. The developers of this model or some other party are paying for this model's compute.</p>
       {% else %}
-        <p> {% if not can_run %}You must sign-up to run models on this platform.{% endif %} The models are offered for free, but you pay for the computational resources used to run them. The prices are equal to AWS compute pricing, subject to costing at least one penny for a single run.  </p>
+        <p> The models are offered for free, but you pay for the computational resources used to run them. The prices are equal to AWS compute pricing, subject to costing at least one penny for a single run.  </p>
           <ul>
             <li>The price per hour of a server running this model is: {{ rate }}</li>
             <li>The expected time required for a single run of this model is: {{exp_time}}</li>

--- a/templates/comp/project_info.html
+++ b/templates/comp/project_info.html
@@ -5,14 +5,14 @@
 {% if provided_free %}
   <p> This model is provided for free. The developers of this model or some other party are paying for this model's compute.</p>
 {% else %}
-  <p> {% if not can_run %}You must sign-up to run models on this platform.{% endif %} The models are offered for free, but you pay for the computational resources used to run them. The prices are equal to AWS compute pricing, subject to costing at least one penny for a single run.  </p>
+  <p> {% if not user_can_run %}You must sign-up to run models on this platform.{% endif %} The models are offered for free, but you pay for the computational resources used to run them. The prices are equal to AWS compute pricing, subject to costing at least one penny for a single run.  </p>
     <ul>
       <li>The price per hour of a server running this model is: {{ rate }}</li>
       <li>The expected time required for a single run of this model is: {{exp_time}}</li>
     </ul>
   </p>
   <p> The average cost of one run for this model is: {{ exp_cost }}</p>
-  {% if not can_run %}
+  {% if not user_can_run %}
   <a href="{% url 'signup' %}" class="btn btn-block btn-match-nav" style="width:150px;">Signup</a>
   {% endif %}
 {% endif %}

--- a/webapp/apps/comp/tests/test_views.py
+++ b/webapp/apps/comp/tests/test_views.py
@@ -178,6 +178,13 @@ class CoreAbstractViewsTest:
             assert resp.status_code == 302
             assert resp.url == f"/billing/update/?next={self.project.app_url}"
 
+    def test_sim_doesnt_exist_gives_404(self, db, client):
+        """
+        Test get sim results that don't exist throws a 404.
+        """
+        resp = client.get(f"{self.project.app_url}/100000/")
+        assert resp.status_code == 404
+
     def login_client(self, client, user, password):
         """
         Helper method to login client

--- a/webapp/apps/comp/views.py
+++ b/webapp/apps/comp/views.py
@@ -44,7 +44,7 @@ class InputsMixin:
     def project_context(self, request, project):
         user = request.user
         provided_free = project.sponsor is not None
-        can_run = self.can_run(user)
+        user_can_run = self.user_can_run(user, project)
         rate = round(project.server_cost, 2)
         exp_cost, exp_time = project.exp_job_info(adjust=True)
 
@@ -53,13 +53,32 @@ class InputsMixin:
             "project_name": project.title,
             "owner": project.owner.user.username,
             "app_description": project.safe_description,
-            "can_run": can_run,
+            "user_can_run": user_can_run,
             "exp_cost": f"${exp_cost}",
             "exp_time": f"{exp_time} seconds",
             "provided_free": provided_free,
             "app_url": project.app_url,
         }
         return context
+
+    def user_can_run(self, user, project):
+        """
+        The user_can_run method determines if the user has sufficient
+        credentials for running this model. The result of this method is
+        used to determine which buttons and information is displayed to the
+        user regarding their credential status (not logged in v. logged in
+        without payment v. logged in with payment). Note that this is actually
+        enforced by RequiresLoginInputsView and RequiresPmtView.
+        """
+        # only requires login and active account.
+        if project.sponsor is not None:
+            return user.is_authenticated and is_profile_active(user)
+        else:  # requires payment method too.
+            return (
+                user.is_authenticated
+                and is_profile_active(user)
+                and has_payment_method(user)
+            )
 
 
 class RouterView(InputsMixin, View):
@@ -169,21 +188,12 @@ class InputsView(InputsMixin, View):
         )
         return render(request, self.template_name, context)
 
-    def can_run(self, user):
-        raise NotImplementedError()
-
 
 class RequiresLoginInputsView(InputsView):
     @method_decorator(login_required)
     @method_decorator(user_passes_test(is_profile_active, login_url="/users/login/"))
     def post(self, request, *args, **kwargs):
         return super().post(request, *args, **kwargs)
-
-    def can_run(self, user):
-        """
-        Test if user can run a given model.
-        """
-        return user.is_authenticated and is_profile_active(user)
 
 
 class RequiresPmtInputsView(InputsView):
@@ -198,13 +208,6 @@ class RequiresPmtInputsView(InputsView):
     )
     def post(self, request, *args, **kwargs):
         return super().post(request, *args, **kwargs)
-
-    def can_run(self, user):
-        return (
-            user.is_authenticated
-            and is_profile_active(user)
-            and has_payment_method(user)
-        )
 
 
 class GetOutputsObjectMixin:

--- a/webapp/apps/comp/views.py
+++ b/webapp/apps/comp/views.py
@@ -209,8 +209,11 @@ class RequiresPmtInputsView(InputsView):
 
 class GetOutputsObjectMixin:
     def get_object(self, pk, username, title):
-        return self.model.objects.get(
-            pk=pk, project__title=title, project__owner__user__username=username
+        return get_object_or_404(
+            self.model,
+            pk=pk,
+            project__title=title,
+            project__owner__user__username=username,
         )
 
 


### PR DESCRIPTION
- Throw 404 if a simulation does not exist. Previously, this resulted in a 500 error.
- The edit page did not have a `can_run` method and threw an error when it was loaded. This PR renames `can_run` to `user_can_run` and moves it to the `InputsMixin` class.
