### PR TITLE
Push simulation results from workers to the webapp

### DIFF
--- a/distributed/api/celery_app/__init__.py
+++ b/distributed/api/celery_app/__init__.py
@@ -4,9 +4,13 @@ import functools
 import traceback
 from collections import defaultdict
 
+import requests
+
 from celery import Celery
 from celery.signals import task_postrun
 from celery.result import AsyncResult
+
+COMP_URL = os.environ.get("COMP_URL")
 
 CELERY_BROKER_URL = os.environ.get("CELERY_BROKER_URL", "redis://localhost:6379")
 CELERY_RESULT_BACKEND = os.environ.get(
@@ -54,3 +58,22 @@ def task_wrapper(func):
         return res
 
     return f
+
+
+@task_postrun.connect
+def post_results(sender=None, headers=None, body=None, **kwargs):
+    print(f'task_id: {kwargs["task_id"]}')
+    print(f'task: {kwargs["task"]} {kwargs["task"].name}')
+    print(f'is sim: {kwargs["task"].name.endswith("sim")}')
+    print(f'state: {kwargs["state"]}')
+    kwargs["retval"]["job_id"] = kwargs["task_id"]
+    if kwargs["task"].name.endswith("sim"):
+        print(f"posting data to {COMP_URL}/outputs/api/")
+        resp = requests.put(
+            f"{COMP_URL}/outputs/api/",
+            json=kwargs["retval"],
+            auth=("comp-api", "heyhey2222"),
+        )
+        print("resp", resp.status_code)
+        if resp.status_code == 400:
+            print("errors", resp.json())

--- a/distributed/api/celery_app/__init__.py
+++ b/distributed/api/celery_app/__init__.py
@@ -11,6 +11,8 @@ from celery.signals import task_postrun
 from celery.result import AsyncResult
 
 COMP_URL = os.environ.get("COMP_URL")
+COMP_API_USER = os.environ.get("COMP_API_USER")
+COMP_API_USER_PASS = os.environ.get("COMP_API_USER_PASS")
 
 CELERY_BROKER_URL = os.environ.get("CELERY_BROKER_URL", "redis://localhost:6379")
 CELERY_RESULT_BACKEND = os.environ.get(
@@ -72,7 +74,7 @@ def post_results(sender=None, headers=None, body=None, **kwargs):
         resp = requests.put(
             f"{COMP_URL}/outputs/api/",
             json=kwargs["retval"],
-            auth=("comp-api", "heyhey2222"),
+            auth=(COMP_API_USER, COMP_API_USER_PASS),
         )
         print("resp", resp.status_code)
         if resp.status_code == 400:

--- a/distributed/docker-compose.yml
+++ b/distributed/docker-compose.yml
@@ -35,8 +35,8 @@ services:
     depends_on:
       - redis
       - celerybase
-    environment:
-      - COMP_URL=${COMP_URL}
+    env_file:
+      - ./dockerfiles/dev.env
     networks:
       - comp_comp-net
   hdoupe_matchups_io:
@@ -48,8 +48,8 @@ services:
     depends_on:
       - redis
       - celerybase
-    environment:
-      - COMP_URL=${COMP_URL}
+    env_file:
+      - ./dockerfiles/dev.env
     networks:
       - comp_comp-net
 
@@ -61,11 +61,11 @@ services:
     environment:
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+    env_file:
+      - ./dockerfiles/dev.env
     depends_on:
       - redis
       - celerybase
-    environment:
-      - COMP_URL=${COMP_URL}
     networks:
       - comp_comp-net
   pslmodels_taxbrain_io:
@@ -77,8 +77,8 @@ services:
     depends_on:
       - redis
       - celerybase
-    environment:
-      - COMP_URL=${COMP_URL}
+    env_file:
+      - ./dockerfiles/dev.env
     networks:
       - comp_comp-net
 
@@ -91,8 +91,8 @@ services:
     depends_on:
       - redis
       - celerybase
-    environment:
-      - COMP_URL=${COMP_URL}
+    env_file:
+      - ./dockerfiles/dev.env
     networks:
       - comp_comp-net
   error_app_io:
@@ -104,8 +104,8 @@ services:
     depends_on:
       - redis
       - celerybase
-    environment:
-      - COMP_URL=${COMP_URL}
+    env_file:
+      - ./dockerfiles/dev.env
     networks:
       - comp_comp-net
 

--- a/distributed/docker-compose.yml
+++ b/distributed/docker-compose.yml
@@ -35,6 +35,8 @@ services:
     depends_on:
       - redis
       - celerybase
+    environment:
+      - COMP_URL=${COMP_URL}
     networks:
       - comp_comp-net
   hdoupe_matchups_io:
@@ -46,6 +48,8 @@ services:
     depends_on:
       - redis
       - celerybase
+    environment:
+      - COMP_URL=${COMP_URL}
     networks:
       - comp_comp-net
 
@@ -60,6 +64,8 @@ services:
     depends_on:
       - redis
       - celerybase
+    environment:
+      - COMP_URL=${COMP_URL}
     networks:
       - comp_comp-net
   pslmodels_taxbrain_io:
@@ -71,6 +77,8 @@ services:
     depends_on:
       - redis
       - celerybase
+    environment:
+      - COMP_URL=${COMP_URL}
     networks:
       - comp_comp-net
 
@@ -83,6 +91,8 @@ services:
     depends_on:
       - redis
       - celerybase
+    environment:
+      - COMP_URL=${COMP_URL}
     networks:
       - comp_comp-net
   error_app_io:
@@ -94,6 +104,8 @@ services:
     depends_on:
       - redis
       - celerybase
+    environment:
+      - COMP_URL=${COMP_URL}
     networks:
       - comp_comp-net
 

--- a/distributed/dockerfiles/dev.env
+++ b/distributed/dockerfiles/dev.env
@@ -1,0 +1,3 @@
+COMP_URL=http://web:8000
+COMP_API_USER=comp-api-user
+COMP_API_USER_PASS=heyhey2222

--- a/distributed/dockerfiles/projects/Dockerfile.hdoupe_matchups_tasks
+++ b/distributed/dockerfiles/projects/Dockerfile.hdoupe_matchups_tasks
@@ -7,7 +7,7 @@ RUN pip install -r requirements.txt
 # Edit Dockerfile here for installing necessary packages, copying files, etc.
 ######################
 RUN conda install pandas pyarrow bokeh paramtools -c pslmodels
-RUN pip install pybaseball matchups==0.3.6
+RUN pip install pybaseball matchups>=0.4.0
 ######################
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - LOCAL=True
     ports:
       - "8000:8000"
+    container_name: web
     depends_on:
       - db
     networks:

--- a/webapp/apps/billing/tests/test_models.py
+++ b/webapp/apps/billing/tests/test_models.py
@@ -151,6 +151,7 @@ class TestStripeModels:
         client.login(username=u.username, password="syncer2222")
         post_data = {
             "title": "New-Model",
+            "oneliner": "one liner",
             "description": "**Super** new!",
             "package_defaults": "import newmodel",
             "parse_user_adjustments": "import newmodel",

--- a/webapp/apps/billing/utils.py
+++ b/webapp/apps/billing/utils.py
@@ -14,20 +14,20 @@ class ChargeRunMixin:
     the logic for charging users for model runs.
     """
 
-    def charge_run(self, meta_dict, use_stripe=True):
-        self.object.run_time = sum(meta_dict["task_times"])
-        self.object.run_cost = self.object.project.run_cost(self.object.run_time)
+    def charge_run(self, sim, meta_dict, use_stripe=True):
+        sim.run_time = sum(meta_dict["task_times"])
+        sim.run_cost = sim.project.run_cost(sim.run_time)
         if use_stripe:
-            quantity = self.object.project.run_cost(self.object.run_time, adjust=True)
-            plan = self.object.project.product.plans.get(usage_type="metered")
+            quantity = sim.project.run_cost(sim.run_time, adjust=True)
+            plan = sim.project.product.plans.get(usage_type="metered")
             # The sponsor is also stored on the Simulation object. However, the
             # Project object should be considered the single source of truth
             # for sending usage records.
-            sponsor = self.object.project.sponsor
+            sponsor = sim.project.sponsor
             if sponsor is not None:
                 customer = sponsor.user.customer
             else:
-                customer = self.object.owner.user.customer
+                customer = sim.owner.user.customer
             si = SubscriptionItem.objects.get(
                 subscription__customer=customer, plan=plan
             )

--- a/webapp/apps/comp/serializers.py
+++ b/webapp/apps/comp/serializers.py
@@ -1,0 +1,9 @@
+from rest_framework import serializers
+
+
+class OutputsSerializer(serializers.Serializer):
+    job_id = serializers.UUIDField()
+    status = serializers.ChoiceField(choices=(("SUCCESS", "Success"), ("FAIL", "Fail")))
+    result = serializers.JSONField(required=False)
+    traceback = serializers.CharField(required=False)
+    meta = serializers.JSONField()

--- a/webapp/apps/comp/tests/compute.py
+++ b/webapp/apps/comp/tests/compute.py
@@ -65,6 +65,8 @@ class MockPushCompute(MockCompute):
             content_type="application/json",
         )
         assert resp.status_code == 200
+        self.client = None
+        self.sim = None
         with requests_mock.Mocker() as mock:
             text = "NO"
             mock.register_uri("GET", url, text=text)

--- a/webapp/apps/comp/tests/test_views.py
+++ b/webapp/apps/comp/tests/test_views.py
@@ -9,7 +9,7 @@ from django.urls import reverse
 from webapp.apps.users.models import Project, Profile
 
 from webapp.apps.comp.models import Simulation
-from .compute import MockCompute
+from .compute import MockCompute, MockPushCompute
 
 
 User = auth.get_user_model()

--- a/webapp/apps/comp/tests/test_views.py
+++ b/webapp/apps/comp/tests/test_views.py
@@ -15,8 +15,36 @@ from .compute import MockCompute, MockPushCompute
 User = auth.get_user_model()
 
 
+class CoreTestMixin:
+    def login_client(self, client, user, password):
+        """
+        Helper function to login client
+        """
+        success = client.login(username=user.username, password=password)
+        assert success
+        return success
+
+    @property
+    def provided_free(self):
+        raise NotImplementedError()
+
+    def inputs_ok(self):
+        return {"has_errors": False}
+
+    def outputs_ok(self):
+        raise NotImplementedError()
+
+    @property
+    def project(self):
+        if getattr(self, "_project", None) is None:
+            self._project = Project.objects.get(
+                owner__user__username=self.owner, title=self.title
+            )
+        return self._project
+
+
 @pytest.mark.django_db
-class CoreAbstractViewsTest:
+class CoreAbstractViewsTest(CoreTestMixin):
     """
     Abstract test class to be used for efficient testing of modeling projects.
     The approach used here goes against conventional wisdom to use simple,
@@ -28,7 +56,6 @@ class CoreAbstractViewsTest:
     title = "Core"
     post_data_ok = {}
     mockcompute = None
-    RunModel = Simulation
 
     def test_get(self, monkeypatch, client):
         """
@@ -128,7 +155,7 @@ class CoreAbstractViewsTest:
         resp = client.get(resp.url)
         assert resp.status_code == 200
 
-        output = self.RunModel.objects.get(model_pk=slug, project=self.project)
+        output = Simulation.objects.get(model_pk=slug, project=self.project)
         assert output.owner
         assert output.project
         assert output.project.server_cost
@@ -184,32 +211,6 @@ class CoreAbstractViewsTest:
         """
         resp = client.get(f"{self.project.app_url}/100000/")
         assert resp.status_code == 404
-
-    def login_client(self, client, user, password):
-        """
-        Helper method to login client
-        """
-        success = client.login(username=user.username, password=password)
-        assert success
-        return success
-
-    @property
-    def provided_free(self):
-        raise NotImplementedError()
-
-    def inputs_ok(self):
-        return {"has_errors": False}
-
-    def outputs_ok(self):
-        raise NotImplementedError()
-
-    @property
-    def project(self):
-        if getattr(self, "_project", None) is None:
-            self._project = Project.objects.get(
-                owner__user__username=self.owner, title=self.title
-            )
-        return self._project
 
 
 def read_outputs(outputs_name):
@@ -279,6 +280,75 @@ class TestMatchupsSponsored(CoreAbstractViewsTest):
         return True
 
 
+@pytest.mark.usefixtures("sponsored_matchups")
+class TestPush(CoreTestMixin):
+    class MatchupsMockPushCompute(MockPushCompute):
+        outputs = read_outputs("Matchups_1")
+
+    owner = "hdoupe"
+    title = "Matchups"
+    mockcompute = MatchupsMockPushCompute
+
+    def inputs_ok(self):
+        inputs = super().inputs_ok()
+        upstream_inputs = {"pitcher": "Max Scherzer"}
+        return dict(inputs, **upstream_inputs)
+
+    def outputs_ok(self):
+        return read_outputs("Matchups_1")
+
+    @property
+    def provided_free(self):
+        return True
+
+    def test_post(self, monkeypatch, client, password, profile):
+        """
+        Tests:
+        1. POST with logged-in user returns 302 redirect which means the sim
+           was kicked off.
+        2. Retrieve the simulation object and pass that to the mockcompute
+           class as a class attribute. (I know it's hacky.)
+        3. Do a POST to simulate an AJAX request from the loading page.
+           MockPushCompute mocks the request to the celery workers with
+           response indicating that the results are not ready, and pushes the
+           outputs via a PUT on the /outputs/api endpoint. The OutputsView
+           returns a 202 indicating that the results are not yet ready.
+        4. Check to make sure that the PUT was successful.
+        5. Do another AJAX like POST and make sure the outputs are found on the
+           simulation object and a 200 is returned.
+        """
+        # Set client as a class attribute.
+        self.mockcompute.client = client
+        monkeypatch.setattr("webapp.apps.comp.views.Compute", self.mockcompute)
+
+        self.login_client(client, profile.user, password)
+        resp = client.post(self.project.app_url, data=self.inputs_ok())
+        assert resp.status_code == 302  # redirect
+        idx = resp.url[:-1].rfind("/")
+        slug = resp.url[(idx + 1) : -1]
+        sim_url = resp.url
+        assert sim_url == f"{self.project.app_url}{slug}/"
+
+        # Pass the sim object to the Compute instance via a class attribute.
+        sim = Simulation.objects.get(project=self.project, model_pk=slug)
+        self.mockcompute.sim = sim
+
+        # test get ouputs page
+        resp = client.post(resp.url)
+        # redirect since the outputs have only just been set.
+        assert resp.status_code == 202
+
+        # output should now be set!
+        sim = Simulation.objects.get(project=self.project, model_pk=slug)
+        assert sim.outputs
+        assert sim.aggr_outputs
+        assert sim.run_time
+        assert sim.project.run_cost(sim.run_time, adjust=True) > 0
+
+        resp = client.post(sim_url)
+        assert resp.status_code == 200
+
+
 def test_404_owner_title_view(db, client):
     resp = client.get("/hello/world/")
     assert resp.status_code == 404
@@ -298,3 +368,22 @@ def test_placeholder_page(db, client):
     resp = client.get(f"/{owner}/{title}/")
     assert resp.status_code == 200
     assert "comp/inputs_form.html" in [t.name for t in resp.templates]
+
+
+def test_outputs_api(db, client, profile, password):
+    # Test auth errors return 401.
+    anon_user = auth.get_user(client)
+    assert not anon_user.is_authenticated
+    assert client.put("/outputs/api/").status_code == 401
+    client.login(username=profile.user.username, password=password)
+    assert client.put("/outputs/api/").status_code == 401
+
+    # Test data errors return 400
+    user = User.objects.get(username="comp-api-user")
+    client.login(username=user.username, password="heyhey2222")
+    assert (
+        client.put(
+            "/outputs/api/", data={"bad": "data"}, content_type="application/json"
+        ).status_code
+        == 400
+    )

--- a/webapp/apps/comp/views.py
+++ b/webapp/apps/comp/views.py
@@ -320,7 +320,7 @@ class OutputsAPIView(RecordOutputsMixin, APIView):
     """
 
     def put(self, request, *args, **kwargs):
-        if request.user.is_authenticated and request.user.username == "comp-api":
+        if request.user.is_authenticated and request.user.username == "comp-api-user":
             ser = OutputsSerializer(data=request.data)
             if ser.is_valid():
                 data = ser.validated_data

--- a/webapp/apps/comp/views.py
+++ b/webapp/apps/comp/views.py
@@ -324,7 +324,7 @@ class OutputsAPIView(RecordOutputsMixin, APIView):
             ser = OutputsSerializer(data=request.data)
             if ser.is_valid():
                 data = ser.validated_data
-                sim = Simulation.objects.get(job_id=data["job_id"])
+                sim = get_object_or_404(Simulation, job_id=data["job_id"])
                 self.record_outputs(sim, data)
                 return Response(status=status.HTTP_200_OK)
             else:

--- a/webapp/apps/comp/views.py
+++ b/webapp/apps/comp/views.py
@@ -15,6 +15,10 @@ from django.urls import reverse
 from django.core.exceptions import PermissionDenied
 from django.core.mail import send_mail
 
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status
+
 from webapp.settings import DEBUG
 
 from webapp.apps.billing.models import SubscriptionItem, UsageRecord
@@ -31,6 +35,7 @@ from .displayer import Displayer
 from .submit import handle_submission, BadPost
 from .tags import TAGS
 from .exceptions import AppError
+from .serializers import OutputsSerializer
 
 
 class InputsMixin:
@@ -293,7 +298,42 @@ class EditInputsView(GetOutputsObjectMixin, InputsMixin, View):
         return render(request, self.template_name, context)
 
 
-class OutputsView(GetOutputsObjectMixin, ChargeRunMixin, DetailView):
+class RecordOutputsMixin(ChargeRunMixin):
+    def record_outputs(self, sim, data):
+        self.charge_run(sim, data["meta"], use_stripe=USE_STRIPE)
+        sim.meta_data = data["meta"]
+        # successful run
+        if data["status"] == "SUCCESS":
+            sim.outputs = data["result"]["outputs"]
+            sim.aggr_outputs = data["result"]["aggr_outputs"]
+            sim.save()
+        # failed run, exception is caught
+        else:
+            sim.traceback = data["traceback"]
+            sim.save()
+
+
+class OutputsAPIView(RecordOutputsMixin, APIView):
+    """
+    API endpoint used by the workers to update the Simulation object with the
+    simulation results.
+    """
+
+    def put(self, request, *args, **kwargs):
+        if request.user.is_authenticated and request.user.username == "comp-api":
+            ser = OutputsSerializer(data=request.data)
+            if ser.is_valid():
+                data = ser.validated_data
+                sim = Simulation.objects.get(job_id=data["job_id"])
+                self.record_outputs(sim, data)
+                return Response(status=status.HTTP_200_OK)
+            else:
+                return Response(ser.errors, status=status.HTTP_400_BAD_REQUEST)
+        else:
+            return Response(status=status.HTTP_401_UNAUTHORIZED)
+
+
+class OutputsView(GetOutputsObjectMixin, RecordOutputsMixin, DetailView):
     """
     This view is the single page of diplaying a progress bar for how
     close the job is to finishing, and then it will also display the
@@ -375,27 +415,19 @@ class OutputsView(GetOutputsObjectMixin, ChargeRunMixin, DetailView):
                     self.object.traceback = str(e)
                     self.object.save()
                     return self.fail(model_pk, username, title)
-                self.charge_run(results["meta"], use_stripe=USE_STRIPE)
-                self.object.meta_data = results["meta"]
-                # successful run
-                if results["status"] == "SUCCESS":
-                    self.object.outputs = results["result"]["outputs"]
-                    self.object.aggr_outputs = results["result"]["aggr_outputs"]
-                    self.object.save()
-                # failed run, exception is caught
-                else:
-                    self.object.traceback = results["traceback"]
-                    self.object.save()
+                self.record_outputs(self.object, results)
+                if results["status"] != "SUCCESS":
                     return self.fail(model_pk, username, title)
-                return render(
-                    request,
-                    "comp/sim_detail.html",
-                    {
-                        "object": self.object,
-                        "result_header": "Results",
-                        "tags": TAGS[self.object.project.title],
-                    },
-                )
+                else:
+                    return render(
+                        request,
+                        "comp/sim_detail.html",
+                        {
+                            "object": self.object,
+                            "result_header": "Results",
+                            "tags": TAGS[self.object.project.title],
+                        },
+                    )
             else:
                 if request.method == "POST":
                     # if not ready yet, insert number of minutes remaining

--- a/webapp/apps/conftest.py
+++ b/webapp/apps/conftest.py
@@ -52,6 +52,14 @@ def django_db_setup(django_db_setup, django_db_blocker):
         Profile.objects.create(user=sponsor, is_active=True)
         Profile.objects.create(user=hdoupe, is_active=True)
 
+        # User for pushing outputs from the workers to the webapp.
+        comp_api_user = User.objects.create_user(
+            username="comp-api-user",
+            email="comp-api-user@email.com",
+            password="heyhey2222",
+        )
+        Profile.objects.create(user=comp_api_user, is_active=True)
+
         common = {
             "description": "[Matchups](https://github.com/hdoupe/Matchups) provides pitch data on pitcher and batter matchups.. Select a date range using the format YYYY-MM-DD. Keep in mind that Matchups only provides data on matchups going back to 2008. Two datasets are offered to run this model: one that only has the most recent season, 2018, and one that contains data on every single pitch going back to 2008. Next, select your favorite pitcher and some batters who he's faced in the past. Click submit to start analyzing the selected matchups!",
             "oneliner": "oneliner",

--- a/webapp/urls.py
+++ b/webapp/urls.py
@@ -16,8 +16,10 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 
-from webapp.apps.users import views as userviews
+from webapp.apps.comp import views as compviews
 from webapp.apps.publish import views as publishviews
+from webapp.apps.users import views as userviews
+
 
 urlpatterns = [
     # admin apps
@@ -27,6 +29,7 @@ urlpatterns = [
     path("users/", include("webapp.apps.users.urls")),
     path("users/", include("django.contrib.auth.urls")),
     path("billing/", include("webapp.apps.billing.urls")),
+    path("outputs/api/", compviews.OutputsAPIView.as_view(), name="outputs_api"),
     path(
         "<str:username>/<str:title>/detail/",
         publishviews.ProjectDetailView.as_view(),


### PR DESCRIPTION
Prior to this PR the webapp polled the workers until the simulation was complete. This PR allows the workers to push the simulation results back to the webapp when they are complete. 

Prior to this PR, the only ways for the webapp to retrieve the result from a simulation was for the user to wait on the loading page for the simulation to complete or to come back later and click on the simulation link to view the outputs. The former method is annoying for long-running simulations. This PR means that the webapp can notify the user when their simulation is complete. The latter method could be problematic if the Redis cache, which is where the results are stored on the workers, is lost. For example, this could happen whenever the Redis service is swapped to a new server. In this case, the result would be lost.

This PR adds a REST API endpoint that allows a user with the username`comp-api-user` (I've already claimed this username) to update simulation objects using the internal simulation outputs format.
