### PR TITLE
Set low resource requests for all io pods

### DIFF
--- a/distributed/app_writer.py
+++ b/distributed/app_writer.py
@@ -87,6 +87,8 @@ if __name__ == "__main__":
             req = copy.deepcopy(resource_req[action])
             resources = dict(req, **copy.deepcopy(obj["resources"]))
             if action == "io":
+                resources["requests"]["cpu"] = "700m"
+                resources["limits"]["cpu"] = "1000m"
                 resources["requests"]["memory"] = "250Mi"
                 resources["limits"]["memory"] = "700Mi"
 


### PR DESCRIPTION
All current inputs processing/validating pods have low resource requirements. This PR sets a low resource request for these pods at 0.7 CPU's and and 250 Mi. If a project has a higher resource needs for getting the default inputs or doing validation, I'm happy to up these requests for that project.