### PR TITLE
Make sure cs-jobs dependency not wiped out during project install

### DIFF
--- a/workers/cs_workers/dockerfiles/Dockerfile.appbase
+++ b/workers/cs_workers/dockerfiles/Dockerfile.appbase
@@ -11,6 +11,6 @@ RUN conda config --append channels conda-forge && \
     pip install gunicorn \
     "cs-kit>=1.16.9" \
     pytest \
-    "git+https://github.com/compute-tooling/compute-studio.git@${BRANCH}#egg=cs-jobs&subdirectory=jobs"
+    cs-jobs
 
 WORKDIR /home

--- a/workers/cs_workers/dockerfiles/Dockerfile.model
+++ b/workers/cs_workers/dockerfiles/Dockerfile.model
@@ -16,7 +16,6 @@ ARG TIME_STAMP=0
 RUN git clone -b ${REPO_TAG} ${REPO_URL}
 WORKDIR ${REPO_NAME}
 
-
 RUN csk build-env
 
 RUN if test -f "./cs-config/install.sh"; then  cat ./cs-config/install.sh; fi
@@ -24,6 +23,8 @@ RUN if test -f "./cs-config/install.sh"; then  bash ./cs-config/install.sh; fi
 
 RUN if test -f "./cs-config/setup.py"; then  pip install -e ./cs-config; fi
 
+# Check if cs-jobs package was removed when installing the project's dependencies.
+RUN if ! cs-jobs --help -- $?; then pip install --no-dependencies cs-jobs; fi
 
 ######################
 


### PR DESCRIPTION
I also put `cs-jobs` package on pypi to make the commands a little easier to work with: https://pypi.org/search/?q=cs-jobs